### PR TITLE
Update margin for copy-tweet-button

### DIFF
--- a/share-tweet-copy/script.user.js
+++ b/share-tweet-copy/script.user.js
@@ -122,7 +122,6 @@
     box-sizing: border-box;
     width: var(--button-diameter);
     height: var(--button-diameter);
-    margin-left: 8px;
     border-radius: var(--button-border-radius);
     background-color: var(--button-bg);
     color: var(--button-text-color);
@@ -131,6 +130,10 @@
     position: relative;
     outline: var(--button-outline-width) solid transparent;
     transition: all 0.2s ease;
+  }
+  
+  *:has(+ .copy-tweet-button) {
+    margin-right: 8px !important;
   }
 
   .tooltip {


### PR DESCRIPTION
We can use the `has` selector to do this by using the CSS selector to select the DOM before the copy button, so that there is no blank space in front of the copy button on the /status page. After adding this, you can reconsider whether you want to continue with the `handleTempStyleStatusPage` function.